### PR TITLE
migrate aws eks example to aws-ia v5

### DIFF
--- a/examples/aws-eks-blueprint-example/outputs.tf
+++ b/examples/aws-eks-blueprint-example/outputs.tf
@@ -1,4 +1,4 @@
 output "configure_kubectl" {
   description = "Configure kubectl: make sure you're logged in with the correct AWS profile and run the following command to update your kubeconfig"
-  value       = module.eks_blueprints.configure_kubectl
+  value       = "aws eks update-kubeconfig --region ${var.region} --name ${eks.cluster_name}"
 }

--- a/examples/aws-eks-blueprint-example/versions.tf
+++ b/examples/aws-eks-blueprint-example/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.4.1"
+      version = ">= 2.8.0"
     }
     kubectl = {
       source  = "gavinbunney/kubectl"

--- a/modules/k8s-protection-agent/versions.tf
+++ b/modules/k8s-protection-agent/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     helm = {
       source  = "hashicorp/helm"
-      version = "2.8.0"
+      version = ">= 2.8.0"
     }
   }
 }


### PR DESCRIPTION
migrate to aws-ia v5: **Per AWS:** EKS Blueprints will remove its Amazon EKS cluster Terraform module components (control plane, EKS managed node group, self-managed node group, and Fargate profile modules) from the project. In its place, users are encouraged to utilize the [terraform-aws-eks](https://github.com/terraform-aws-modules/terraform-aws-eks) more info: https://aws-ia.github.io/terraform-aws-eks-blueprints/main/ 

kubectl configure command: new aws eks module does not have kubectl configure in output, manually construct this value with cluster name and region

update helm provider version: upgrade helm provider version to >=2.8.0 in k8s-protection-agent module