### PR TITLE
remove sensors on destroy

### DIFF
--- a/modules/operator/destroy.tf
+++ b/modules/operator/destroy.tf
@@ -1,0 +1,18 @@
+
+resource "null_resource" "remove_container_sensor" {
+  count = var.sensor_type == "FalconContainer" ? 1 : 0
+  provisioner "local-exec" {
+    command = "kubectl delete falconcontainers.falcon.crowdstrike.com --all"
+    when = destroy
+  }
+  depends_on = [ kubectl_manifest.falcon_operator ]
+}
+
+resource "null_resource" "remove_node_sensor" {
+  count = var.sensor_type == "FalconNodeSensor" ? 1 : 0
+  provisioner "local-exec" {
+    command = "kubectl delete falconnodesensors --all"
+    when = destroy
+  }
+  depends_on = [ kubectl_manifest.falcon_operator ]
+}


### PR DESCRIPTION
Fixes #28

Use local-exec provisioners, dependent on operator resource, to delete sensors from cluster before destroying the operator and cluster.