### PR TITLE
0.4.0 updates

### DIFF
--- a/examples/aws-eks-blueprint-example/main.tf
+++ b/examples/aws-eks-blueprint-example/main.tf
@@ -56,6 +56,7 @@ module "eks" {
 
   vpc_id     = module.vpc.vpc_id
   subnet_ids = module.vpc.private_subnets
+  cluster_endpoint_public_access = true
 
   eks_managed_node_groups = {
     blue = {}
@@ -89,7 +90,7 @@ module "eks_blueprints_kubernetes_addons" {
 
 module "crowdstrike_falcon" {
   source  = "CrowdStrike/falcon/kubectl"
-  version = "0.3.0"
+  version = "0.4.0"
 
   cid              = var.cid
   client_id        = var.client_id

--- a/examples/aws-eks-blueprint-example/outputs.tf
+++ b/examples/aws-eks-blueprint-example/outputs.tf
@@ -1,4 +1,4 @@
 output "configure_kubectl" {
   description = "Configure kubectl: make sure you're logged in with the correct AWS profile and run the following command to update your kubeconfig"
-  value       = "aws eks update-kubeconfig --region ${var.region} --name ${eks.cluster_name}"
+  value       = "aws eks update-kubeconfig --region ${var.region} --name ${module.eks.cluster_name}"
 }

--- a/modules/k8s-protection-agent/main.tf
+++ b/modules/k8s-protection-agent/main.tf
@@ -1,17 +1,6 @@
-resource "null_resource" "lower_cid" {
-  provisioner "local-exec" {
-    command = <<-EOF
-      cid=${var.cid}
-      trim_cid=$(echo $cid | rev | cut -c 4- | rev)
-      my_cid=$(echo $trim_cid | tr '[:upper:]' '[:lower:]')
-      printf $my_cid > cid.txt
-    EOF
-  }
-}
-
-data "local_file" "lower_cid" {
-    filename = "cid.txt"
-  depends_on = [null_resource.lower_cid]
+locals {
+  lower_cid = "${lower(var.cid)}"
+  cid_split = "${split("-", local.lower_cid)}"
 }
 
 resource "helm_release" "kpagent" {
@@ -44,7 +33,7 @@ resource "helm_release" "kpagent" {
 
   set {
     name  = "crowdstrikeConfig.cid"
-    value = data.local_file.lower_cid.content
+    value = local.cid_split[0]
   }
 
   set {

--- a/modules/k8s-protection-agent/main.tf
+++ b/modules/k8s-protection-agent/main.tf
@@ -1,3 +1,19 @@
+resource "null_resource" "lower_cid" {
+  provisioner "local-exec" {
+    command = <<-EOF
+      cid=${var.cid}
+      trim_cid=$(echo $cid | rev | cut -c 4- | rev)
+      my_cid=$(echo $trim_cid | tr '[:upper:]' '[:lower:]')
+      printf $my_cid > cid.txt
+    EOF
+  }
+}
+
+data "local_file" "lower_cid" {
+    filename = "cid.txt"
+  depends_on = [null_resource.lower_cid]
+}
+
 resource "helm_release" "kpagent" {
   name             = "kpagent"
   chart            = "cs-k8s-protection-agent"
@@ -28,7 +44,7 @@ resource "helm_release" "kpagent" {
 
   set {
     name  = "crowdstrikeConfig.cid"
-    value = var.cid
+    value = data.local_file.lower_cid.content
   }
 
   set {


### PR DESCRIPTION
[fix output reference](https://github.com/CrowdStrike/terraform-kubectl-falcon/commit/c27e6c1d64d85e1e5eaa27100a6f5e143f916d96)
EKS Cluster Name output must reference module

[lower cid for kpa](https://github.com/CrowdStrike/terraform-kubectl-falcon/commit/199f5f9787769ab832465c0d0bb6e28971402177)
KPA requires lower-case cid with no checksum

[add public endpoint for eks](https://github.com/CrowdStrike/terraform-kubectl-falcon/commit/698c8cc16783f1e4e30a22a709a570063e80ee67)
EKS public access endpoint required for TF to run helm/kubectl remotely.  See: https://docs.aws.amazon.com/eks/latest/userguide/cluster-endpoint.html