### PR TITLE
Fix Broken Links

### DIFF
--- a/modules/operator/README.md
+++ b/modules/operator/README.md
@@ -11,7 +11,7 @@ Falcon Node Sensor and Falcon Container Sensor are CrowdStrike products that pro
 
 If you choose to install Falcon Node Sensor the operator will manage Kubernetes DaemonSet for you to deploy the Node Sensor onto each node of your kubernetes cluster. Alternatively, if you choose to install Falcon Container Sensor the operator will set-up deployment hook on your cluster so every new deployment will get Falcon Container inserted in each pod.
 
-Detailed documentation for [FalconNodeSensor](https://github.com/CrowdStrike/falcon-operator/tree/main/docs/node) and [FalconContainer](https://github.com/CrowdStrike/falcon-operator/tree/main/docs/container) can be found in the [falcon-operator](https://github.com/CrowdStrike/falcon-operator) repository.
+Detailed documentation for [FalconNodeSensor](https://github.com/CrowdStrike/falcon-operator/tree/main/docs/resources/node) and [FalconContainer](https://github.com/CrowdStrike/falcon-operator/tree/main/docs/resources/container) can be found in the [falcon-operator](https://github.com/CrowdStrike/falcon-operator) repository.
 
 ## Pre-requisites
 

--- a/modules/operator/docs/.header.md
+++ b/modules/operator/docs/.header.md
@@ -10,7 +10,7 @@ Falcon Node Sensor and Falcon Container Sensor are CrowdStrike products that pro
 
 If you choose to install Falcon Node Sensor the operator will manage Kubernetes DaemonSet for you to deploy the Node Sensor onto each node of your kubernetes cluster. Alternatively, if you choose to install Falcon Container Sensor the operator will set-up deployment hook on your cluster so every new deployment will get Falcon Container inserted in each pod.
 
-Detailed documentation for [FalconNodeSensor](https://github.com/CrowdStrike/falcon-operator/tree/main/docs/node) and [FalconContainer](https://github.com/CrowdStrike/falcon-operator/tree/main/docs/container) can be found in the [falcon-operator](https://github.com/CrowdStrike/falcon-operator) repository.
+Detailed documentation for [FalconNodeSensor](https://github.com/CrowdStrike/falcon-operator/tree/main/docs/resources/node) and [FalconContainer](https://github.com/CrowdStrike/falcon-operator/tree/main/docs/resources/container) can be found in the [falcon-operator](https://github.com/CrowdStrike/falcon-operator) repository.
 
 ## Pre-requisites
 


### PR DESCRIPTION
There are multiple broken links in the documentation of this project. Here is what I have fixed:

https://github.com/CrowdStrike/falcon-operator/tree/main/docs/node --> https://github.com/CrowdStrike/falcon-operator/tree/main/docs/resources/node

https://github.com/CrowdStrike/falcon-operator/tree/main/docs/container --> https://github.com/CrowdStrike/falcon-operator/tree/main/docs/resources/container

I found this links using a tool I created called [link-inspector](https://github.com/justindhillon/link-inspector). If you find this PR useful, give the repo a :star: 

I have also applied to the [Software Engineer Intern - Summer 2024 (Remote)](https://crowdstrike.wd5.myworkdayjobs.com/en-us/crowdstrikecareers/job/USA---Remote/Software-Engineer-Intern---Summer-2024--Remote-_R15417?utm_source=Simplify&ref=Simplify) position at your company. If you could put a word in for me, it would be greatly appreciated.

- Fixes #34