### PR TITLE
feat: add ability to configure operating mode for the node sensor

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -7,6 +7,7 @@ module "falcon_operator" {
   environment      = var.environment
   falcon_admission = var.falcon_admission
   operator_version = var.operator_version
+  node_sensor_mode = var.node_sensor_mode
 }
 
 module "falcon_kpa" {

--- a/modules/operator/main.tf
+++ b/modules/operator/main.tf
@@ -37,6 +37,8 @@ resource "kubectl_manifest" "falcon_node_sensor" {
         client_id: ${var.client_id}
         client_secret: ${var.client_secret}
         cloud_region: autodiscover
+      node:
+        backend: ${var.node_sensor_mode}
     YAML
   depends_on = [
     kubectl_manifest.falcon_operator

--- a/modules/operator/variables.tf
+++ b/modules/operator/variables.tf
@@ -33,6 +33,18 @@ variable "operator_version" {
   default     = "v0.9.1"
 }
 
+variable "node_sensor_mode" {
+  description = "Falcon Node Sensor mode: 'kernel' or 'bpf'."
+  type        = string
+  default     = "bpf"
+
+  validation {
+    condition     = contains(["kernel", "bpf"], var.node_sensor_mode)
+    error_message = "Falcon Node Sensor must be kernel or bpf."
+  }
+
+}
+
 variable "falcon_admission" {
   description = "Whether to deploy the FalconAdmission Custom Resource (CR) to the cluster."
   type        = bool

--- a/variables.tf
+++ b/variables.tf
@@ -59,6 +59,18 @@ variable "operator_version" {
   default     = "v0.9.1"
 }
 
+variable "node_sensor_mode" {
+  description = "Falcon Node Sensor mode: 'kernel' or 'bpf'."
+  type        = string
+  default     = "bpf"
+
+  validation {
+    condition     = contains(["kernel", "bpf"], var.node_sensor_mode)
+    error_message = "Falcon Node Sensor must be kernel or bpf."
+  }
+
+}
+
 variable "falcon_admission" {
   type        = bool
   description = "Whether to deploy the FalconAdmission Custom Resource (CR) to the cluster."


### PR DESCRIPTION
- Node sensor can run either in kernel or bpf mode. Sets the default variable for this to bpf.