### PR TITLE
Bump Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ locals {
 
 module "crowdstrike_falcon" {
   source = "CrowdStrike/falcon/kubectl"
-  version = "0.6.0"
+  version = "0.6.1"
 
   cid              = local.secrets["cid"]
   client_id        = local.secrets["client_id"]

--- a/modules/operator-openshift/main.tf
+++ b/modules/operator-openshift/main.tf
@@ -66,7 +66,7 @@ locals {
     falcon_api:
       client_id: ${var.client_id}
       client_secret: ${var.client_secret}
-      cloud_region: autodiscover
+      cloud_region: ${var.cloud}
     node:
       backend: ${var.node_sensor_mode}
   EOT
@@ -79,7 +79,7 @@ locals {
     falcon_api:
       client_id: ${var.client_id}
       client_secret: ${var.client_secret}
-      cloud_region: autodiscover
+      cloud_region: ${var.cloud}
     registry:
       type: crowdstrike
     falcon:

--- a/modules/operator/main.tf
+++ b/modules/operator/main.tf
@@ -49,7 +49,7 @@ locals {
     falcon_api:
       client_id: ${var.client_id}
       client_secret: ${var.client_secret}
-      cloud_region: autodiscover
+      cloud_region: ${var.cloud}
     registry:
       type: crowdstrike
     falcon:
@@ -65,7 +65,7 @@ locals {
     falcon_api:
       client_id: ${var.client_id}
       client_secret: ${var.client_secret}
-      cloud_region: autodiscover
+      cloud_region: ${var.cloud}
     registry:
       type: crowdstrike
     falcon:


### PR DESCRIPTION
Bump release to force terraform module to consume latest changes.

Bump version in usage block in main readme.

Explicitly pass falcon cloud for node & container sensor.