### PR TITLE
Fix kubectl provider propagation for newer Terraform and OpenTofu versions

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -17,6 +17,10 @@ module "falcon_operator" {
   admission_controller_manifest_path = var.admission_controller_manifest_path
   iar_manifest_path                  = var.iar_manifest_path
   cleanup                            = var.cleanup
+  providers = {
+    kubectl = kubectl
+  }
+
 }
 
 module "falcon_operator_openshift" {


### PR DESCRIPTION
This PR fixes an issue where the kubectl provider was not correctly propagated to nested modules in the CrowdStrike Falcon module when using newer versions of Terraform (>=1.4) and OpenTofu. Previously, the provider inheritance worked automatically in older Terraform versions, but newer versions require explicit provider forwarding to avoid connection errors.